### PR TITLE
Align angle controls to right

### DIFF
--- a/style.css
+++ b/style.css
@@ -757,13 +757,11 @@
 .screen .frame-26 {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: flex-end;
   gap: 24px;
-  padding: 0px 0px 0px 24px;
+  padding: 0;
   position: relative;
-  flex: 1;
-  align-self: stretch;
-  flex-grow: 1;
+  margin-left: auto;
 }
 
 .screen .text-wrapper-19 {
@@ -790,6 +788,11 @@
   flex: 0 0 auto;
 }
 
+.screen .frame-26 .frame-27 {
+  align-self: flex-end;
+  width: auto;
+}
+
 .screen .frame-28 {
   display: flex;
   flex-direction: column;
@@ -798,6 +801,11 @@
   position: relative;
   flex: 1;
   flex-grow: 1;
+}
+
+.screen .frame-26 .frame-28 {
+  align-items: flex-end;
+  text-align: right;
 }
 
 .screen .text-wrapper-20 {


### PR DESCRIPTION
## Summary
- adjust the angle controls aside so it sits against the right edge of the panel
- right-align the current and required angle values for clearer presentation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7c5be3f1083238957f90c91f58e8b