### PR TITLE
Handle connection attempt visibility by attempt count

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,13 +730,21 @@
         return;
       }
 
+      const attemptNumber = Number(rawAttempt);
+      const hasValidAttemptNumber = Number.isFinite(attemptNumber);
+      const shouldShowAttempt = hasValidAttemptNumber && attemptNumber >= 0 && attemptNumber <= 2;
+      const shouldShowDetails = hasValidAttemptNumber && attemptNumber === 4;
+
+      if (shouldShowDetails || !shouldShowAttempt) {
+        connectionAttemptSection.hidden = true;
+        if (connectionDetailsSection) connectionDetailsSection.hidden = false;
+        return;
+      }
+
       connectionAttemptSection.hidden = false;
       if (connectionDetailsSection) connectionDetailsSection.hidden = true;
 
-      const attemptNumber = Number(rawAttempt);
-      const displayAttemptText = Number.isFinite(attemptNumber) && attemptNumber === 0
-        ? 'ноль'
-        : attemptTextRaw;
+      const displayAttemptText = attemptNumber === 0 ? 'ноль' : attemptTextRaw;
 
       if (connectionAttemptNumber) {
         connectionAttemptNumber.textContent = displayAttemptText;


### PR DESCRIPTION
## Summary
- update the connection attempt view logic so attempts 0–2 show the attempt section while attempt 4 reveals the connection details

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8024a30dc8323a1fc7797bb712f27