### PR TITLE
Hide temperature meter until data is available

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
                       <div class="div-3">Температура модема</div>
                     </div>
                     <div class="state-default">
-                      <div class="frame-11 meter" id="temp-meter" role="meter" aria-valuenow="-30" aria-valuemin="-30"
+                      <div class="frame-11 meter" id="temp-meter" role="meter" aria-valuemin="-30"
                         aria-valuemax="85" aria-label="Температура модема — данные не получены" data-pending="true">
                         <div class="rectangle rectangle-4 meter__fill"></div>
                         <div class="rectangle-2 meter__rest"></div>

--- a/style.css
+++ b/style.css
@@ -1632,6 +1632,20 @@
   transition: flex-grow .25s ease;
 }
 
+.meter[data-pending="true"] .meter__fill {
+  flex-grow: 0 !important;
+  width: 0 !important;
+  min-width: 0;
+  background-color: #d9d9d9;
+  border-radius: 10px;
+}
+
+.meter[data-pending="true"] .meter__rest {
+  flex-grow: 1 !important;
+  background-color: #d9d9d9;
+  border-radius: 10px;
+}
+
 /* верхний ряд карточек: все в одну строку */
 .frame-5 {
   display: grid !important;


### PR DESCRIPTION
## Summary
- remove the initial temperature value from the modem temperature meter markup so it starts in a pending state
- add styling for meters marked as pending so the fill is hidden until live data arrives

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da34d95e708323a2f01909842e437b