### PR TITLE
Align auto shutdown checkbox styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,10 +287,15 @@
                   </fieldset>
                 </div>
 
-                <label class="temp-alert__auto" for="auto-shutdown-hot">
-                  <input id="auto-shutdown-hot" type="checkbox" class="temp-alert__checkbox" />
-                  Выключать автоматически при опасных температурах
-                </label>
+                <div class="temp-alert__auto checkbox-w-label">
+                  <input id="auto-shutdown-hot" type="checkbox" class="checkbox-input sr-only" />
+                  <label for="auto-shutdown-hot" class="checkbox">
+                    <div class="rectangle-3"></div>
+                  </label>
+                  <label for="auto-shutdown-hot" class="label temp-alert__auto-label">
+                    <span class="title-3">Выключать автоматически при опасных температурах</span>
+                  </label>
+                </div>
               </div>
             </section>
 

--- a/style.css
+++ b/style.css
@@ -1548,15 +1548,16 @@
   display: inline-flex;
   gap: 8px;
   align-items: center;
-  color: #404040;
-  font: 400 14px/1.2 "Roboto", Arial, sans-serif;
 }
 
-.temp-alert__checkbox {
-  width: 18px;
-  height: 18px;
-  accent-color: #0b74d0;
-  /* нативная синяя галочка как на скрине */
+.temp-alert__auto .label {
+  padding: 4px 0;
+}
+
+.temp-alert__auto .title-3 {
+  white-space: normal;
+  line-height: 1.35;
+  text-align: left;
 }
 
 .modem-controls {


### PR DESCRIPTION
## Summary
- refactor the auto shutdown control markup to reuse the shared checkbox pattern
- adjust styles so the modem auto-shutdown label wraps and matches the edit checkbox visuals

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68db94d6dd208323b18c3e12fa02cc8a