### PR TITLE
Update connection detail copy based on attempt state

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,18 +123,9 @@
         <section class="frame-13" aria-label="Детали подключения и управление">
           <div class="frame-14">
 
-            <section id="connection-attempt" class="connection-attempt" hidden>
-              <h2 class="connection-attempt__title">Идёт подключение…</h2>
-              <p id="connection-attempt-attempt" class="connection-attempt__attempt">Попытка <span
-                  id="connection-attempt-number">1</span> из <span id="connection-attempt-total">3</span></p>
-              <p id="connection-attempt-eta-wrapper" class="connection-attempt__eta">Подождите ~<span
-                  id="connection-attempt-eta">3</span> мин</p>
-              <p id="connection-attempt-error" class="connection-attempt__error" hidden>Перезагрузить, что-то пошло не
-                так</p>
-            </section>
-
             <section id="connection-details" class="frame-15">
-              <h2 class="text-wrapper-9">Детали подключения</h2>
+              <h2 id="connection-details-title" class="text-wrapper-9">H2вариант 0</h2>
+              <p id="connection-details-subtitle" class="connection-subtitle">Pвариант 0</p>
 
               <div class="frame-16">
 
@@ -681,18 +672,26 @@
     const beamNumberField = document.getElementById('beam-number-value');
     const rfClusterField = document.getElementById('rf-cluster-polarization-value');
 
-    const connectionAttemptSection = document.getElementById('connection-attempt');
     const connectionDetailsSection = document.getElementById('connection-details');
-    const connectionAttemptTitle = connectionAttemptSection?.querySelector('.connection-attempt__title') || null;
-    const connectionAttemptAttempt = document.getElementById('connection-attempt-attempt');
-    const connectionAttemptNumber = document.getElementById('connection-attempt-number');
-    const connectionAttemptTotal = document.getElementById('connection-attempt-total');
-    const connectionAttemptEta = document.getElementById('connection-attempt-eta');
-    const connectionAttemptEtaWrapper = document.getElementById('connection-attempt-eta-wrapper');
-    const connectionAttemptError = document.getElementById('connection-attempt-error');
-    const ATTEMPT_TOTAL = 3;
-    const CONNECTION_ATTEMPT_TITLE_DEFAULT = 'Идёт подключение…';
-    const CONNECTION_ATTEMPT_TITLE_ERROR = 'Что-то пошло не так';
+    const connectionDetailsTitle = document.getElementById('connection-details-title');
+    const connectionDetailsSubtitle = document.getElementById('connection-details-subtitle');
+    const CONNECTION_DETAIL_VARIANTS = [
+      { title: 'H2вариант 0', subtitle: 'Pвариант 0' },
+      { title: 'H2вариант 1', subtitle: 'Pвариант 1' },
+      { title: 'H2вариант 2', subtitle: 'Pвариант 2' },
+      { title: 'H2вариант 3', subtitle: 'Pвариант 3' },
+      { title: 'H2вариант 4', subtitle: 'Pвариант 4' },
+      { title: 'H2вариант 5', subtitle: 'Pвариант 5' },
+      { title: 'H2вариант 6', subtitle: 'Pвариант 6' },
+      { title: 'H2вариант 7', subtitle: 'Pвариант 7' },
+      { title: 'H2вариант 8', subtitle: 'Pвариант 8' },
+      { title: 'H2вариант 9', subtitle: 'Pвариант 9' },
+      { title: 'H2вариант 10', subtitle: 'Pвариант 10' }
+    ];
+    const defaultConnectionDetails = {
+      title: connectionDetailsTitle?.textContent || CONNECTION_DETAIL_VARIANTS[0].title,
+      subtitle: connectionDetailsSubtitle?.textContent || CONNECTION_DETAIL_VARIANTS[0].subtitle
+    };
 
     const initialIndicatorTexts = {
       power: indicators.power?.text?.textContent || '',
@@ -737,6 +736,10 @@
       coordsStatusText: initialIndicatorTexts.coords,
       gpsStatusText: initialIndicatorTexts.gps,
       inetStatusText: initialIndicatorTexts.inet,
+      connectionDetails: {
+        title: connectionDetailsTitle?.textContent || defaultConnectionDetails.title,
+        subtitle: connectionDetailsSubtitle?.textContent || defaultConnectionDetails.subtitle
+      },
       wifiPasswordView: wifiPasswordView?.textContent || '',
       wifiPasswordInput: wifiPasswordInput?.value || '',
       modemStatusText: modemStatusInitial?.textContent || '',
@@ -888,47 +891,19 @@
       });
     }
 
-    /* ===== ПРОСТАЯ ЛОГИКА ПОКАЗ/СКРЫТИЕ ATTEMPT/DETAILS ===== */
+    /* ===== ВЫБОР ВАРИАНТА ТЕКСТА ДЛЯ ДЕТАЛЕЙ ПОДКЛЮЧЕНИЯ ===== */
     function updateConnectionAttemptView(state = {}) {
-      const n = Number(state.attempt);
-      const showAttempt = Number.isFinite(n) && n >= 0 && n <= ATTEMPT_TOTAL;
-      const isErrorAttempt = showAttempt && n >= ATTEMPT_TOTAL;
+      if (connectionDetailsSection) connectionDetailsSection.hidden = false;
 
-      if (connectionAttemptSection) {
-        connectionAttemptSection.hidden = !showAttempt;
-        connectionAttemptSection.classList.toggle('connection-attempt--error', Boolean(isErrorAttempt));
-      }
-      if (connectionDetailsSection) connectionDetailsSection.hidden = showAttempt;
-
-      if (!showAttempt) return;
-
-      if (connectionAttemptTitle) {
-        connectionAttemptTitle.textContent = isErrorAttempt
-          ? CONNECTION_ATTEMPT_TITLE_ERROR
-          : CONNECTION_ATTEMPT_TITLE_DEFAULT;
+      const attemptNumber = Number(state.attempt);
+      let variant = defaultConnectionDetails;
+      if (Number.isFinite(attemptNumber) && attemptNumber >= 0) {
+        const normalizedIndex = Math.min(CONNECTION_DETAIL_VARIANTS.length - 1, Math.floor(attemptNumber));
+        variant = CONNECTION_DETAIL_VARIANTS[normalizedIndex] || defaultConnectionDetails;
       }
 
-      if (connectionAttemptAttempt) connectionAttemptAttempt.hidden = Boolean(isErrorAttempt);
-      if (connectionAttemptError) connectionAttemptError.hidden = !isErrorAttempt;
-
-      if (isErrorAttempt) {
-        if (connectionAttemptNumber) connectionAttemptNumber.textContent = '';
-        if (connectionAttemptTotal) connectionAttemptTotal.textContent = '';
-        if (connectionAttemptEtaWrapper) connectionAttemptEtaWrapper.hidden = true;
-        return;
-      }
-
-      if (connectionAttemptNumber) connectionAttemptNumber.textContent = String(n + 1);
-      if (connectionAttemptTotal) connectionAttemptTotal.textContent = String(ATTEMPT_TOTAL);
-
-      const etaSec = Number(state.eta_sec);
-      if (Number.isFinite(etaSec) && etaSec > 0) {
-        const m = Math.max(1, Math.round(etaSec / 60));
-        if (connectionAttemptEta) connectionAttemptEta.textContent = String(m);
-        if (connectionAttemptEtaWrapper) connectionAttemptEtaWrapper.hidden = false;
-      } else if (connectionAttemptEtaWrapper) {
-        connectionAttemptEtaWrapper.hidden = true;
-      }
+      if (connectionDetailsTitle) connectionDetailsTitle.textContent = variant.title || defaultConnectionDetails.title;
+      if (connectionDetailsSubtitle) connectionDetailsSubtitle.textContent = variant.subtitle || defaultConnectionDetails.subtitle;
     }
 
     function resetInterfaceToInitialState() {
@@ -987,17 +962,9 @@
       updateAngleMatchState(angleFields.rotateCurrent, null, null);
 
       renderLogs([]);
-      updateConnectionAttemptView({});
-      if (connectionAttemptSection) {
-        connectionAttemptSection.classList.remove('connection-attempt--error');
-        connectionAttemptSection.hidden = true;
-      }
-      if (connectionAttemptTitle) connectionAttemptTitle.textContent = CONNECTION_ATTEMPT_TITLE_DEFAULT;
-      if (connectionAttemptAttempt) connectionAttemptAttempt.hidden = false;
-      if (connectionAttemptError) connectionAttemptError.hidden = true;
-      if (connectionAttemptNumber) connectionAttemptNumber.textContent = '';
-      if (connectionAttemptTotal) connectionAttemptTotal.textContent = '';
-      if (connectionAttemptEtaWrapper) connectionAttemptEtaWrapper.hidden = true;
+      updateConnectionAttemptView({ attempt: 0 });
+      if (connectionDetailsTitle) connectionDetailsTitle.textContent = initialViewState.connectionDetails.title;
+      if (connectionDetailsSubtitle) connectionDetailsSubtitle.textContent = initialViewState.connectionDetails.subtitle;
 
       setInteractiveControlsDisabled(true);
     }
@@ -1284,7 +1251,7 @@
 
       if ('logs' in state) renderLogs(state.logs);
 
-      // Показываем/скрываем "Идёт подключение…" vs "Детали"
+      // Обновляем текст "Детали подключения" в зависимости от attempt
       updateConnectionAttemptView(state);
 
       if ('system' in state) {

--- a/style.css
+++ b/style.css
@@ -506,6 +506,14 @@ a {
   font-style: var(--m3-title-large-font-style);
 }
 
+.connection-subtitle {
+  margin: 4px 0 16px;
+  font-family: "Roboto", Helvetica;
+  font-size: 16px;
+  line-height: 24px;
+  color: #8c8c8c;
+}
+
 .screen .frame-16 {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- remove the connection attempt section and always display the connection details card
- update the dashboard script to swap connection detail title/subtitle variants using the attempt value
- add styling for the new connection subtitle element

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bbe1f64c8323ba91e21c0549a247