### PR TITLE
Ensure RF cluster polarization value remains black

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,15 +703,15 @@
       const clusterNumbers = parseNumbersFromString(normalizedClusterRaw);
 
       if (beamNumber == null || clusterNumbers.length === 0) {
-        rfClusterField.style.color = '';
+        rfClusterField.style.color = 'var(--black)';
         if (beamNumberField) beamNumberField.style.color = '';
         return;
       }
 
       const hasMatch = clusterNumbers.includes(beamNumber);
-      const colorValue = hasMatch ? 'var(--black)' : 'red';
-      rfClusterField.style.color = colorValue;
-      if (beamNumberField) beamNumberField.style.color = colorValue;
+      const beamColor = hasMatch ? 'var(--black)' : 'red';
+      rfClusterField.style.color = 'var(--black)';
+      if (beamNumberField) beamNumberField.style.color = beamColor;
     }
 
     const connectionDetailsSection = document.getElementById('connection-details');


### PR DESCRIPTION
## Summary
- keep the RF cluster polarization value text color fixed to black while
  continuing to highlight the beam number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3de41f29083239d1e588d9cd8adba