### PR TITLE
Fix mobile coordinates status icon size

### DIFF
--- a/style.css
+++ b/style.css
@@ -1782,6 +1782,9 @@ a {
   inline-size: 24px;
   block-size: 24px;
   display: inline-block;
+  flex: 0 0 auto;
+  min-inline-size: 24px;
+  min-block-size: 24px;
 }
 
 /* Размеры (если где-то нужен 28px) */
@@ -2759,7 +2762,6 @@ a {
     white-space: normal;  /* можно переносить */
   }
 }
-
 
 
 


### PR DESCRIPTION
### Motivation
- The coordinates status icon became visually too small on mobile because SVG icons were allowed to shrink inside flexible layout cells. 
- Preventing the icon from shrinking preserves consistent geometry across status cards and improves readability in the mobile grid.

### Description
- Added non-shrinking sizing to the status icon by updating the `.status-icon` rule in `style.css`. 
- The change adds `flex: 0 0 auto` and minimum inline/block sizes (`min-inline-size: 24px`, `min-block-size: 24px`) to the `.status-icon` selector. 
- This keeps the existing `inline-size`/`block-size` defaults while preventing flex-based compression on small viewports.

### Testing
- Launched a local static server with `python -m http.server 8000` and captured a mobile viewport screenshot using a Playwright script, producing `artifacts/coords-mobile.png`, and the run completed successfully. 
- No automated unit tests were added or run for this CSS-only fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696377d00cb0832393d6eade75658c45)